### PR TITLE
(SIMP-1692) Point fixtures to `5.X` branches

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,4 @@
+---
 fixtures:
   repositories:
     stdlib:
@@ -31,4 +32,4 @@ fixtures:
     augeasproviders_syslog:
       repo: git://github.com/hercules-team/augeasproviders_syslog.git
   symlinks:
-    "augeasproviders": "#{source_dir}"
+    augeasproviders: "#{source_dir}"


### PR DESCRIPTION
This commit marks the transition of mainline SIMP development away from
4.x/5.x.  From this point on, the `master` branch will be used to target SIMP
6.x.

This commit updates `fixtures.yml` to reference the newly-created `5.X` branch
in each `simp/` repository.

SIMP-1692 #comment updated `.fixtures.yml` in augeasproviders
